### PR TITLE
create __main__.py

### DIFF
--- a/p2j/__main__.py
+++ b/p2j/__main__.py
@@ -1,0 +1,6 @@
+import os
+import sys
+from p2j.p2j import main
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
enables calling p2j as a module. which is convenient for controlling multiple python virtual environments.
```sh
python -m p2j <input.py> -t <output.ipynb>
```